### PR TITLE
Tab close events

### DIFF
--- a/Tabalonia/Controls/TabsControl.cs
+++ b/Tabalonia/Controls/TabsControl.cs
@@ -64,6 +64,13 @@ public class TabsControl : TabControl
         AvaloniaProperty.Register<TabsControl, Func<object>?>(nameof(NewItemFactory));
 
 
+    public static readonly StyledProperty<EventHandler<TabClosedEventArgs>?> TabClosedProperty =
+        AvaloniaProperty.Register<TabsControl, EventHandler<TabClosedEventArgs>?>(nameof(TabClosed));
+
+    public static readonly StyledProperty<EventHandler<TabClosingEventArgs>?> TabClosingProperty =
+        AvaloniaProperty.Register<TabsControl, EventHandler<TabClosingEventArgs>?>(nameof(TabClosing));
+
+
     public static readonly StyledProperty<EventHandler<CloseLastTabEventArgs>?> LastTabClosedActionProperty =
         AvaloniaProperty.Register<TabsControl, EventHandler<CloseLastTabEventArgs>?>(nameof(LastTabClosedAction));
 
@@ -170,6 +177,20 @@ public class TabsControl : TabControl
     {
         get => GetValue(NewItemFactoryProperty);
         set => SetValue(NewItemFactoryProperty, value);
+    }
+
+
+    public EventHandler<TabClosedEventArgs>? TabClosed
+    {
+        get => GetValue(TabClosedProperty);
+        set => SetValue(TabClosedProperty, value);
+    }
+
+
+    public EventHandler<TabClosingEventArgs>? TabClosing
+    {
+        get => GetValue(TabClosingProperty);
+        set => SetValue(TabClosingProperty, value);
     }
 
 
@@ -283,9 +304,20 @@ public class TabsControl : TabControl
             return;
 
         int removedItemIndex = itemsList.IndexOf(item);
+
+        if (removedItemIndex == -1)
+            return;
+
+        TabClosingEventArgs tabClosingEventArgs = new(item);
+        TabClosing?.Invoke(this, tabClosingEventArgs);
+        if (tabClosingEventArgs.Cancel)
+            return;
+
         bool removedItemIsSelected = SelectedItem == item;
 
         itemsList.Remove(item);
+
+        TabClosed?.Invoke(this, new TabClosedEventArgs(item));
 
         if (itemsList.Count == 0)
             LastTabClosedAction?.Invoke(this, new CloseLastTabEventArgs(GetThisWindow()));

--- a/Tabalonia/Events/TabClosedEventArgs.cs
+++ b/Tabalonia/Events/TabClosedEventArgs.cs
@@ -1,0 +1,6 @@
+﻿namespace Tabalonia.Events;
+
+public class TabClosedEventArgs(object? item) : EventArgs
+{
+    public object? Item { get; } = item;
+}

--- a/Tabalonia/Events/TabClosingEventArgs.cs
+++ b/Tabalonia/Events/TabClosingEventArgs.cs
@@ -1,0 +1,8 @@
+﻿using System.ComponentModel;
+
+namespace Tabalonia.Events;
+
+public class TabClosingEventArgs(object? item) : CancelEventArgs
+{
+    public object? Item { get; } = item;
+}


### PR DESCRIPTION
Added tab close events. Useful for handling things when a tab is closing. e.g. saving data, displaying prompts, etc.