### PR TITLE
fix: TabsControl Buttons in MyTheme Demo working again

### DIFF
--- a/Tabalonia.Demo/Styles/DragTabItem.axaml
+++ b/Tabalonia.Demo/Styles/DragTabItem.axaml
@@ -155,7 +155,7 @@
 
                             <Button Grid.Column="1"
                                     Theme="{StaticResource CloseItemCommandButton}"
-                                    Command="{Binding $parent[controls:TabsControl].CloseItem}"
+                                    Command="{Binding $parent[controls:TabsControl].CloseItemCommand}"
                                     CommandParameter="{Binding RelativeSource={RelativeSource TemplatedParent}}">
 
                                 <Button.IsVisible>

--- a/Tabalonia.Demo/Styles/TabsControl.axaml
+++ b/Tabalonia.Demo/Styles/TabsControl.axaml
@@ -125,7 +125,7 @@
                             <ItemsPresenter Name="PART_ItemsPresenter"
                                             ItemsPanel="{TemplateBinding ItemsPanel}" />
 
-                            <Button Command="{Binding AddItem, RelativeSource={RelativeSource TemplatedParent}}"
+                            <Button Command="{Binding AddItemCommand, RelativeSource={RelativeSource TemplatedParent}}"
                                     Theme="{StaticResource AddItemCommandButton}" 
                                     IsVisible="{TemplateBinding ShowDefaultAddButton}"/>
 


### PR DESCRIPTION
Hello!

Found something interesting. If yout try to use your custom theme (aka MyTheme) in Tabalonia.Demo, you'll find out that all buttons stop working

Before `(App.axaml)`
```xaml
        <custom:CustomTheme />

         <!--<StyleInclude Source="Styles/MyTheme.axaml" />--> 
```

After `(App.axaml)`
```xaml
        <!-- <custom:CustomTheme /> -->

         <StyleInclude Source="Styles/MyTheme.axaml" /> 
```

I've noticed that MyTheme in Demo is your implementation of Fluent Theme. So, I compared them and found out that in MyTheme there are some little typos in command bindings. 