### PR TITLE
Improve Left/Right thumb drag and double tap behavior

### DIFF
--- a/Tabalonia/Controls/TabsControl.cs
+++ b/Tabalonia/Controls/TabsControl.cs
@@ -231,18 +231,6 @@ public class TabsControl : TabControl
         rightDragWindowThumb.DoubleTapped += WindowDragThumbOnDoubleTapped;
     }
 
-    private void OnThumbBeginDrag(object? sender, PointerPressedEventArgs e)
-    {
-        var toplevel = TopLevel.GetTopLevel(this);
-        if(toplevel is not Window window) return;
-        if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed ||
-            e.GetCurrentPoint(this).Pointer.Type == PointerType.Touch)
-        {
-            window.BeginMoveDrag(e);
-        }
-    }
-
-
     protected override Control CreateContainerForItemOverride(object? item, int index, object? recycleKey) =>
         new DragTabItem();
 
@@ -414,6 +402,16 @@ public class TabsControl : TabControl
         }
     }
 
+    private void OnThumbBeginDrag(object? sender, PointerPressedEventArgs e)
+    {
+        var toplevel = TopLevel.GetTopLevel(this);
+        if(toplevel is not Window window) return;
+        if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed ||
+            e.GetCurrentPoint(this).Pointer.Type == PointerType.Touch)
+        {
+            window.BeginMoveDrag(e);
+        }
+    }
 
     private void WindowDragThumbOnDoubleTapped(object? sender, RoutedEventArgs e)
     {
@@ -422,7 +420,7 @@ public class TabsControl : TabControl
         window?.RestoreWindow();
     }
 
-
+    [Obsolete]
     private void WindowDragThumbOnDragDelta(object? sender, VectorEventArgs e)
     {
         var window = this.FindLogicalAncestorOfType<Window>();

--- a/Tabalonia/Controls/TabsControl.cs
+++ b/Tabalonia/Controls/TabsControl.cs
@@ -221,12 +221,25 @@ public class TabsControl : TabControl
         base.OnApplyTemplate(e);
 
         var leftDragWindowThumb = e.NameScope.Get<Thumb>("PART_LeftDragWindowThumb");
-        leftDragWindowThumb.DragDelta += WindowDragThumbOnDragDelta;
+        leftDragWindowThumb.AddHandler(PointerPressedEvent, OnThumbBeginDrag, handledEventsToo: true);
+        //leftDragWindowThumb.DragDelta += WindowDragThumbOnDragDelta;
         leftDragWindowThumb.DoubleTapped += WindowDragThumbOnDoubleTapped;
 
         var rightDragWindowThumb = e.NameScope.Get<Thumb>("PART_RightDragWindowThumb");
-        rightDragWindowThumb.DragDelta += WindowDragThumbOnDragDelta;
+        rightDragWindowThumb.AddHandler(PointerPressedEvent, OnThumbBeginDrag, handledEventsToo: true);
+        // rightDragWindowThumb.DragDelta += WindowDragThumbOnDragDelta;
         rightDragWindowThumb.DoubleTapped += WindowDragThumbOnDoubleTapped;
+    }
+
+    private void OnThumbBeginDrag(object? sender, PointerPressedEventArgs e)
+    {
+        var toplevel = TopLevel.GetTopLevel(this);
+        if(toplevel is not Window window) return;
+        if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed ||
+            e.GetCurrentPoint(this).Pointer.Type == PointerType.Touch)
+        {
+            window.BeginMoveDrag(e);
+        }
     }
 
 

--- a/Tabalonia/Extensions.cs
+++ b/Tabalonia/Extensions.cs
@@ -20,8 +20,9 @@ internal static class Extensions
     {
         if (window is null)
             return;
-
-        window.WindowState = WindowState.Maximized;
+        if (!window.CanResize) return;
+        if (window.WindowState == WindowState.FullScreen) return;
+        window.WindowState = window.WindowState == WindowState.Maximized ? WindowState.Normal : WindowState.Maximized;
     }
 
 


### PR DESCRIPTION
1. Use `Window.BeginMoveDrag` to simplify window position calculation
2. Consider window state on double tap. 