### PR TITLE
work in progress tab detach and reattach support

### DIFF
--- a/Tabalonia/Controls/DragTabItem.cs
+++ b/Tabalonia/Controls/DragTabItem.cs
@@ -148,19 +148,19 @@ public class DragTabItem : TabItem
 
     private void ThumbOnDragStarted(object? sender, VectorEventArgs args)
     {
-        RaiseEvent(new DragTabDragStartedEventArgs(DragStarted, this, args));
+        RaiseEvent(new DragTabDragStartedEventArgs(DragStarted, this, args, _thumb.LastScreenPoint));
     }
 
     
     private void ThumbOnDragDelta(object? sender, VectorEventArgs e)
     {
-        var previewEventArgs = new DragTabDragDeltaEventArgs(PreviewDragDelta, this, e);
+        var previewEventArgs = new DragTabDragDeltaEventArgs(PreviewDragDelta, this, e, _thumb.LastScreenPoint);
         RaiseEvent(previewEventArgs);
         // if (previewEventArgs.Cancel)
         //     _thumb.CancelDrag();
         if (!previewEventArgs.Handled)
         {
-            var eventArgs = new DragTabDragDeltaEventArgs(DragDelta, this, e);
+            var eventArgs = new DragTabDragDeltaEventArgs(DragDelta, this, e, _thumb.LastScreenPoint);
             RaiseEvent(eventArgs);
             //if (eventArgs.Cancel)
             //    thumb.CancelDrag();
@@ -170,7 +170,7 @@ public class DragTabItem : TabItem
     
     private void ThumbOnDragCompleted(object? sender, VectorEventArgs e)
     {
-        var args = new DragTabDragCompletedEventArgs(DragCompleted, this, e);
+        var args = new DragTabDragCompletedEventArgs(DragCompleted, this, e, _thumb.LastScreenPoint);
         RaiseEvent(args);
     }
 }

--- a/Tabalonia/Controls/LeftPressedThumb.cs
+++ b/Tabalonia/Controls/LeftPressedThumb.cs
@@ -17,6 +17,8 @@ public class LeftPressedThumb : TemplatedControl
 
     
     private Point? _lastPoint;
+
+    public Point? LastScreenPoint { get; private set; }
     
 
     public event EventHandler<VectorEventArgs>? DragStarted
@@ -52,6 +54,7 @@ public class LeftPressedThumb : TemplatedControl
             };
 
             _lastPoint = null;
+            LastScreenPoint = null;
 
             RaiseEvent(ev);
         }
@@ -63,6 +66,8 @@ public class LeftPressedThumb : TemplatedControl
     {
         if (!IsLeftButtonPressed(e))
             return;
+
+        LastScreenPoint = GetScreenPoint(e);
         
         if (_lastPoint.HasValue)
         {
@@ -82,7 +87,9 @@ public class LeftPressedThumb : TemplatedControl
             return;
         
         e.Handled = true;
+        e.Pointer.Capture(this);
         _lastPoint = e.GetPosition(this);
+        LastScreenPoint = GetScreenPoint(e);
 
         var ev = new VectorEventArgs
         {
@@ -98,13 +105,12 @@ public class LeftPressedThumb : TemplatedControl
     
     protected override void OnPointerReleased(PointerReleasedEventArgs e)
     {
-        if (!IsLeftButtonPressed(e))
-            return;
-        
         if (_lastPoint.HasValue)
         {
             e.Handled = true;
             _lastPoint = null;
+            LastScreenPoint = GetScreenPoint(e);
+            e.Pointer.Capture(null);
 
             var ev = new VectorEventArgs
             {
@@ -113,6 +119,8 @@ public class LeftPressedThumb : TemplatedControl
             };
 
             RaiseEvent(ev);
+
+            LastScreenPoint = null;
         }
     }
 
@@ -122,6 +130,20 @@ public class LeftPressedThumb : TemplatedControl
         var point = args.GetCurrentPoint(this);
         
         return point.Properties.IsLeftButtonPressed;
+    }
+
+
+    private Point? GetScreenPoint(PointerEventArgs e)
+    {
+        var topLevel = TopLevel.GetTopLevel(this);
+
+        if (topLevel is null)
+            return null;
+
+        Point pointInTopLevel = e.GetPosition(topLevel);
+        PixelPoint screenPoint = topLevel.PointToScreen(pointInTopLevel);
+
+        return new Point(screenPoint.X, screenPoint.Y);
     }
     
     

--- a/Tabalonia/Controls/TabsControl.cs
+++ b/Tabalonia/Controls/TabsControl.cs
@@ -445,6 +445,19 @@ public class TabsControl : TabControl
 
             SelectedItem = item;
         }
+
+        if (IsDetachedSingleTabHost() && e.ScreenPoint is { } dragStartScreenPoint)
+        {
+            Window? hostWindow = GetThisWindow();
+
+            if (hostWindow is not null)
+            {
+                _dragSessionWindow = hostWindow;
+                _dragSessionWindowPointerOffset = new Vector(
+                    x: dragStartScreenPoint.X - hostWindow.Position.X,
+                    y: dragStartScreenPoint.Y - hostWindow.Position.Y);
+            }
+        }
     }
 
 
@@ -457,10 +470,16 @@ public class TabsControl : TabControl
         {
             _lastKnownDragScreenPoint = screenPoint;
 
-            if (ReferenceEquals(_dragSessionSourceHost, this) && !_isDetachedHost)
+            if (ReferenceEquals(_dragSessionSourceHost, this) && !IsDetachedSingleTabHost())
                 TryDetachDuringDrag(screenPoint);
 
             MoveDragSessionWindow(screenPoint);
+        }
+
+        if (IsDetachedSingleTabHost() && _dragSessionWindow is not null)
+        {
+            e.Handled = true;
+            return;
         }
 
         if (!ReferenceEquals(_dragSessionSourceHost, this))
@@ -497,7 +516,7 @@ public class TabsControl : TabControl
         bool sourceDetachedDuringDrag = !ReferenceEquals(sourceHost, this);
         bool transferredBetweenHosts = TryTransferToAnotherHost(releaseScreenPoint, sourceHost);
 
-        if (!transferredBetweenHosts && !sourceDetachedDuringDrag && !sourceHost._isDetachedHost)
+        if (!transferredBetweenHosts && !sourceDetachedDuringDrag && !sourceHost.IsDetachedSingleTabHost())
             transferredBetweenHosts = TryDetachToNewWindow(releaseScreenPoint);
 
         if (!transferredBetweenHosts && sourceDetachedDuringDrag)
@@ -667,6 +686,10 @@ public class TabsControl : TabControl
         _dragSessionWindow = null;
         _dragSessionWindowPointerOffset = null;
     }
+
+
+    private bool IsDetachedSingleTabHost() =>
+        _isDetachedHost && ItemsSource is IList items && items.Count == 1;
 
 
     private bool MoveItemToAnotherTabsControl(object item, TabsControl target, Point dropScreenPoint)

--- a/Tabalonia/Controls/TabsControl.cs
+++ b/Tabalonia/Controls/TabsControl.cs
@@ -33,9 +33,10 @@ public class TabsControl : TabControl
     private object? _draggedTabModel;
     private bool _dragging;
     private bool _skipMoveTabModelsOnDragCompleted;
-    private bool _isDetachedHost;
-    private Window? _draggedHostWindow;
-    private Vector? _draggedHostWindowPointerOffset;
+    private Point? _lastKnownDragScreenPoint;
+    private TabsControl? _dragSessionSourceHost;
+    private Window? _dragSessionWindow;
+    private Vector? _dragSessionWindowPointerOffset;
 
     private Control? _topPanel;
     private readonly EventHandler<CloseLastTabEventArgs> _defaultLastTabClosedAction;
@@ -426,8 +427,9 @@ public class TabsControl : TabControl
     {
         _draggedItem = e.TabItem;
         _draggedTabModel = ItemFromContainer(_draggedItem);
+        _lastKnownDragScreenPoint = e.ScreenPoint;
+        _dragSessionSourceHost = this;
         _skipMoveTabModelsOnDragCompleted = false;
-        BeginDetachedHostDrag(e.ScreenPoint);
 
         e.Handled = true;
 
@@ -450,7 +452,21 @@ public class TabsControl : TabControl
         if (_draggedItem is null)
             throw new Exception($"{nameof(TabsControl)}.{nameof(ItemDragDelta)} - _draggedItem is null");
 
-        MoveDetachedHostWindow(e.ScreenPoint, e.DragDeltaEventArgs.Vector);
+        if (e.ScreenPoint is { } screenPoint)
+        {
+            _lastKnownDragScreenPoint = screenPoint;
+
+            if (ReferenceEquals(_dragSessionSourceHost, this))
+                TryDetachDuringDrag(screenPoint);
+
+            MoveDragSessionWindow(screenPoint);
+        }
+
+        if (!ReferenceEquals(_dragSessionSourceHost, this))
+        {
+            e.Handled = true;
+            return;
+        }
 
         if (_draggedItem.LogicalIndex < FixedHeaderCount)
         {
@@ -475,10 +491,16 @@ public class TabsControl : TabControl
 
     private void ItemDragCompleted(object? sender, DragTabDragCompletedEventArgs e)
     {
-        bool transferredBetweenHosts = TryTransferToAnotherHost(e);
+        Point? releaseScreenPoint = e.ScreenPoint ?? _lastKnownDragScreenPoint;
+        TabsControl sourceHost = _dragSessionSourceHost ?? this;
+        bool sourceDetachedDuringDrag = !ReferenceEquals(sourceHost, this);
+        bool transferredBetweenHosts = TryTransferToAnotherHost(releaseScreenPoint, sourceHost);
 
-        if (!transferredBetweenHosts)
-            transferredBetweenHosts = TryDetachToNewWindow(e);
+        if (!transferredBetweenHosts && !sourceDetachedDuringDrag)
+            transferredBetweenHosts = TryDetachToNewWindow(releaseScreenPoint);
+
+        if (!transferredBetweenHosts && sourceDetachedDuringDrag)
+            transferredBetweenHosts = true;
 
         _skipMoveTabModelsOnDragCompleted = transferredBetweenHosts;
 
@@ -488,10 +510,14 @@ public class TabsControl : TabControl
             item.IsSiblingDragging = false;
         }
 
+        if (sourceDetachedDuringDrag)
+            sourceHost.EndExternalDragVisualState();
+
         Dispatcher.UIThread.Post(() => _tabsPanel.InvalidateMeasure(), DispatcherPriority.Loaded);
 
         _dragging = false;
-        ResetDetachedHostDragState();
+        _lastKnownDragScreenPoint = null;
+        ResetDragSession();
     }
 
 
@@ -515,7 +541,8 @@ public class TabsControl : TabControl
             _skipMoveTabModelsOnDragCompleted = false;
             _draggedItem = null;
             _draggedTabModel = null;
-            ResetDetachedHostDragState();
+            _lastKnownDragScreenPoint = null;
+            ResetDragSession();
             return;
         }
 
@@ -523,57 +550,8 @@ public class TabsControl : TabControl
 
         _draggedItem = null;
         _draggedTabModel = null;
-        ResetDetachedHostDragState();
-    }
-
-
-    private void BeginDetachedHostDrag(Point? screenPoint)
-    {
-        ResetDetachedHostDragState();
-
-        if (!_isDetachedHost)
-            return;
-
-        Window? hostWindow = GetThisWindow();
-
-        if (hostWindow is null)
-            return;
-
-        _draggedHostWindow = hostWindow;
-
-        if (screenPoint is null)
-            return;
-
-        PixelPoint hostPosition = hostWindow.Position;
-        _draggedHostWindowPointerOffset = new Vector(
-            x: screenPoint.Value.X - hostPosition.X,
-            y: screenPoint.Value.Y - hostPosition.Y);
-    }
-
-
-    private void MoveDetachedHostWindow(Point? screenPoint, Vector dragVector)
-    {
-        if (_draggedHostWindow is null)
-            return;
-
-        if (screenPoint is { } pointerScreenPoint && _draggedHostWindowPointerOffset is { } pointerOffset)
-        {
-            _draggedHostWindow.Position = new PixelPoint(
-                x: (int)Math.Round(pointerScreenPoint.X - pointerOffset.X),
-                y: (int)Math.Round(pointerScreenPoint.Y - pointerOffset.Y));
-
-            return;
-        }
-
-        // Fallback when screen coordinates are unavailable for the current pointer update.
-        _draggedHostWindow.DragWindow(dragVector.X, dragVector.Y);
-    }
-
-
-    private void ResetDetachedHostDragState()
-    {
-        _draggedHostWindow = null;
-        _draggedHostWindowPointerOffset = null;
+        _lastKnownDragScreenPoint = null;
+        ResetDragSession();
     }
 
 
@@ -607,33 +585,86 @@ public class TabsControl : TabControl
     }
 
 
-    private bool TryTransferToAnotherHost(DragTabDragCompletedEventArgs e)
+    private bool TryTransferToAnotherHost(Point? releaseScreenPoint, TabsControl sourceHost)
     {
-        if (!EnableTabAttaching || e.ScreenPoint is null)
+        if (!EnableTabAttaching || !sourceHost.EnableTabAttaching || releaseScreenPoint is null)
             return false;
 
-        if (!TryFindDropTarget(e.ScreenPoint.Value, this, out TabsControl? target))
+        if (!TryFindDropTarget(releaseScreenPoint.Value, sourceHost, out TabsControl? target))
             return false;
 
         if (_draggedTabModel is null)
             return false;
 
-        return MoveItemToAnotherTabsControl(_draggedTabModel, target, e.ScreenPoint.Value);
+        if (target is null)
+            return false;
+
+        return sourceHost.MoveItemToAnotherTabsControl(_draggedTabModel, target, releaseScreenPoint.Value);
     }
 
 
-    private bool TryDetachToNewWindow(DragTabDragCompletedEventArgs e)
+    private bool TryDetachToNewWindow(Point? releaseScreenPoint)
     {
-        if (!EnableTabDetaching || e.ScreenPoint is null)
+        if (!EnableTabDetaching || releaseScreenPoint is null)
             return false;
 
-        if (!ShouldDetachForScreenPoint(e.ScreenPoint.Value))
+        if (!ShouldDetachForScreenPoint(releaseScreenPoint.Value))
             return false;
 
         if (_draggedTabModel is null)
             return false;
 
-        return DetachItemToNewWindow(_draggedTabModel, e.ScreenPoint.Value);
+        return DetachItemToNewWindow(_draggedTabModel, releaseScreenPoint.Value);
+    }
+
+
+    private void TryDetachDuringDrag(Point screenPoint)
+    {
+        if (_draggedTabModel is null || !EnableTabDetaching)
+            return;
+
+        if (!ShouldDetachForScreenPoint(screenPoint))
+            return;
+
+        if (DetachItemToNewWindow(_draggedTabModel, screenPoint, fromDragSession: true, out TabsControl? detachedHost, out Window? detachedWindow))
+        {
+            if (detachedHost is null || detachedWindow is null)
+                return;
+
+            _dragSessionSourceHost = detachedHost;
+            _dragSessionWindow = detachedWindow;
+            _dragSessionWindowPointerOffset = new Vector(120, 20);
+            _skipMoveTabModelsOnDragCompleted = true;
+            _dragging = false;
+
+            foreach (var item in DragTabItems())
+            {
+                item.IsDragging = false;
+                item.IsSiblingDragging = false;
+            }
+
+            Dispatcher.UIThread.Post(() => detachedHost.MarkDraggedItemState(_draggedTabModel), DispatcherPriority.Loaded);
+        }
+    }
+
+
+    private void MoveDragSessionWindow(Point screenPoint)
+    {
+        if (_dragSessionWindow is null)
+            return;
+
+        Vector pointerOffset = _dragSessionWindowPointerOffset ?? new Vector(120, 20);
+        _dragSessionWindow.Position = new PixelPoint(
+            x: (int)Math.Round(screenPoint.X - pointerOffset.X),
+            y: (int)Math.Round(screenPoint.Y - pointerOffset.Y));
+    }
+
+
+    private void ResetDragSession()
+    {
+        _dragSessionSourceHost = null;
+        _dragSessionWindow = null;
+        _dragSessionWindowPointerOffset = null;
     }
 
 
@@ -734,8 +765,20 @@ public class TabsControl : TabControl
     }
 
 
-    private bool DetachItemToNewWindow(object item, Point releaseScreenPoint)
+    private bool DetachItemToNewWindow(object item, Point releaseScreenPoint) =>
+        DetachItemToNewWindow(item, releaseScreenPoint, fromDragSession: false, out _, out _);
+
+
+    private bool DetachItemToNewWindow(
+        object item,
+        Point releaseScreenPoint,
+        bool fromDragSession,
+        out TabsControl? detachedTabsControl,
+        out Window? detachedWindow)
     {
+        detachedTabsControl = null;
+        detachedWindow = null;
+
         if (ItemsSource is not IList sourceItems)
             return false;
 
@@ -744,7 +787,7 @@ public class TabsControl : TabControl
         if (sourceIndex < 0)
             return false;
 
-        TabsControl detachedTabsControl = CreateDetachedTabsControl();
+        detachedTabsControl = CreateDetachedTabsControl();
 
         if (detachedTabsControl.ItemsSource is not IList detachedItems)
             return false;
@@ -756,14 +799,17 @@ public class TabsControl : TabControl
         detachedItems.Add(item);
         detachedTabsControl.SelectedItem = item;
 
-        Window detachedWindow = DetachedWindowFactory?.Invoke(detachedTabsControl)
-                                ?? CreateDefaultDetachedWindow(detachedTabsControl);
+        detachedWindow = DetachedWindowFactory?.Invoke(detachedTabsControl)
+                         ?? CreateDefaultDetachedWindow(detachedTabsControl);
 
         detachedWindow.Position = new PixelPoint(
             x: (int)releaseScreenPoint.X - 120,
             y: (int)releaseScreenPoint.Y - 20);
 
         detachedWindow.Show();
+
+        if (fromDragSession)
+            detachedWindow.Activate();
 
         HandleSourceItemsChangedAfterTransfer(sourceItems, sourceIndex, removedItemWasSelected);
 
@@ -779,7 +825,7 @@ public class TabsControl : TabControl
             TabItemWidth = TabItemWidth,
             ShowDefaultCloseButton = ShowDefaultCloseButton,
             ShowDefaultAddButton = ShowDefaultAddButton,
-            FixedHeaderCount = FixedHeaderCount,
+            FixedHeaderCount = 0,
             NewItemAsyncFactory = NewItemAsyncFactory,
             NewItemFactory = NewItemFactory,
             TabClosed = TabClosed,
@@ -796,13 +842,53 @@ public class TabsControl : TabControl
             DataContext = DataContext
         };
 
-        detachedTabsControl._isDetachedHost = true;
 
         detachedTabsControl.LastTabClosedAction = LastTabClosedAction == _defaultLastTabClosedAction
             ? detachedTabsControl._defaultLastTabClosedAction
             : LastTabClosedAction;
 
         return detachedTabsControl;
+    }
+
+
+    private void MarkDraggedItemState(object? itemModel)
+    {
+        if (itemModel is null)
+            return;
+
+        foreach (var tabItem in DragTabItems())
+        {
+            tabItem.IsDragging = false;
+            tabItem.IsSiblingDragging = true;
+        }
+
+        if (ContainerFromItem(itemModel) is DragTabItem draggedItem)
+        {
+            draggedItem.IsDragging = true;
+            draggedItem.IsSiblingDragging = false;
+            draggedItem.IsSelected = true;
+            _draggedItem = draggedItem;
+            _draggedTabModel = itemModel;
+            _dragging = true;
+        }
+
+        Dispatcher.UIThread.Post(() => _tabsPanel.InvalidateMeasure(), DispatcherPriority.Loaded);
+    }
+
+
+    private void EndExternalDragVisualState()
+    {
+        foreach (var tabItem in DragTabItems())
+        {
+            tabItem.IsDragging = false;
+            tabItem.IsSiblingDragging = false;
+        }
+
+        _dragging = false;
+        _draggedItem = null;
+        _draggedTabModel = null;
+
+        Dispatcher.UIThread.Post(() => _tabsPanel.InvalidateMeasure(), DispatcherPriority.Loaded);
     }
 
 

--- a/Tabalonia/Controls/TabsControl.cs
+++ b/Tabalonia/Controls/TabsControl.cs
@@ -559,7 +559,7 @@ public class TabsControl : TabControl
         if (_draggedTabModel is null)
             return false;
 
-        return MoveItemToAnotherTabsControl(_draggedTabModel, target);
+        return MoveItemToAnotherTabsControl(_draggedTabModel, target, e.ScreenPoint.Value);
     }
 
 
@@ -578,7 +578,7 @@ public class TabsControl : TabControl
     }
 
 
-    private bool MoveItemToAnotherTabsControl(object item, TabsControl target)
+    private bool MoveItemToAnotherTabsControl(object item, TabsControl target, Point dropScreenPoint)
     {
         if (ReferenceEquals(target, this))
             return false;
@@ -592,13 +592,84 @@ public class TabsControl : TabControl
             return false;
 
         bool removedItemWasSelected = Equals(SelectedItem, item);
+        int targetInsertIndex = target.ResolveInsertIndexFromScreenPoint(dropScreenPoint);
 
         sourceItems.RemoveAt(sourceIndex);
 
-        targetItems.Add(item);
+        targetItems.Insert(targetInsertIndex, item);
         target.SelectedItem = item;
 
         HandleSourceItemsChangedAfterTransfer(sourceItems, sourceIndex, removedItemWasSelected);
+
+        return true;
+    }
+
+
+    private int ResolveInsertIndexFromScreenPoint(Point screenPoint)
+    {
+        if (ItemsSource is not IList targetItems)
+            return 0;
+
+        int maxIndex = targetItems.Count;
+        int minIndex = Math.Min(FixedHeaderCount, maxIndex);
+
+        var orderedTabs = DragTabItems()
+            .OrderBy(tab => tab.LogicalIndex)
+            .ToList();
+
+        if (orderedTabs.Count == 0)
+            return minIndex;
+
+        double pointerPosition = GetPointerPrimaryAxis(screenPoint);
+
+        foreach (DragTabItem tab in orderedTabs)
+        {
+            if (tab.LogicalIndex < FixedHeaderCount)
+                continue;
+
+            if (!TryGetTabBoundsInScreen(tab, out Rect tabBounds))
+                continue;
+
+            if (pointerPosition < GetRectMidpoint(tabBounds))
+                return Math.Clamp(tab.LogicalIndex, minIndex, maxIndex);
+        }
+
+        return maxIndex;
+    }
+
+
+    private double GetPointerPrimaryAxis(Point screenPoint) =>
+        TabStripPlacement is Dock.Left or Dock.Right ? screenPoint.Y : screenPoint.X;
+
+
+    private double GetRectMidpoint(Rect rect) =>
+        TabStripPlacement is Dock.Left or Dock.Right
+            ? rect.Y + rect.Height / 2
+            : rect.X + rect.Width / 2;
+
+
+    private static bool TryGetTabBoundsInScreen(Control tab, out Rect bounds)
+    {
+        bounds = default;
+
+        TopLevel? topLevel = TopLevel.GetTopLevel(tab);
+
+        if (topLevel is null)
+            return false;
+
+        Point? topLeftInTopLevel = tab.TranslatePoint(new Point(0, 0), topLevel);
+
+        if (topLeftInTopLevel is null)
+            return false;
+
+        PixelPoint topLeftScreen = topLevel.PointToScreen(topLeftInTopLevel.Value);
+        PixelPoint bottomRightScreen = topLevel.PointToScreen(topLeftInTopLevel.Value + new Vector(tab.Bounds.Width, tab.Bounds.Height));
+
+        bounds = new Rect(
+            x: topLeftScreen.X,
+            y: topLeftScreen.Y,
+            width: Math.Max(1, bottomRightScreen.X - topLeftScreen.X),
+            height: Math.Max(1, bottomRightScreen.Y - topLeftScreen.Y));
 
         return true;
     }

--- a/Tabalonia/Controls/TabsControl.cs
+++ b/Tabalonia/Controls/TabsControl.cs
@@ -33,6 +33,9 @@ public class TabsControl : TabControl
     private object? _draggedTabModel;
     private bool _dragging;
     private bool _skipMoveTabModelsOnDragCompleted;
+    private bool _isDetachedHost;
+    private Window? _draggedHostWindow;
+    private Vector? _draggedHostWindowPointerOffset;
 
     private Control? _topPanel;
     private readonly EventHandler<CloseLastTabEventArgs> _defaultLastTabClosedAction;
@@ -424,6 +427,7 @@ public class TabsControl : TabControl
         _draggedItem = e.TabItem;
         _draggedTabModel = ItemFromContainer(_draggedItem);
         _skipMoveTabModelsOnDragCompleted = false;
+        BeginDetachedHostDrag(e.ScreenPoint);
 
         e.Handled = true;
 
@@ -445,6 +449,8 @@ public class TabsControl : TabControl
     {
         if (_draggedItem is null)
             throw new Exception($"{nameof(TabsControl)}.{nameof(ItemDragDelta)} - _draggedItem is null");
+
+        MoveDetachedHostWindow(e.ScreenPoint, e.DragDeltaEventArgs.Vector);
 
         if (_draggedItem.LogicalIndex < FixedHeaderCount)
         {
@@ -485,6 +491,7 @@ public class TabsControl : TabControl
         Dispatcher.UIThread.Post(() => _tabsPanel.InvalidateMeasure(), DispatcherPriority.Loaded);
 
         _dragging = false;
+        ResetDetachedHostDragState();
     }
 
 
@@ -508,6 +515,7 @@ public class TabsControl : TabControl
             _skipMoveTabModelsOnDragCompleted = false;
             _draggedItem = null;
             _draggedTabModel = null;
+            ResetDetachedHostDragState();
             return;
         }
 
@@ -515,6 +523,57 @@ public class TabsControl : TabControl
 
         _draggedItem = null;
         _draggedTabModel = null;
+        ResetDetachedHostDragState();
+    }
+
+
+    private void BeginDetachedHostDrag(Point? screenPoint)
+    {
+        ResetDetachedHostDragState();
+
+        if (!_isDetachedHost)
+            return;
+
+        Window? hostWindow = GetThisWindow();
+
+        if (hostWindow is null)
+            return;
+
+        _draggedHostWindow = hostWindow;
+
+        if (screenPoint is null)
+            return;
+
+        PixelPoint hostPosition = hostWindow.Position;
+        _draggedHostWindowPointerOffset = new Vector(
+            x: screenPoint.Value.X - hostPosition.X,
+            y: screenPoint.Value.Y - hostPosition.Y);
+    }
+
+
+    private void MoveDetachedHostWindow(Point? screenPoint, Vector dragVector)
+    {
+        if (_draggedHostWindow is null)
+            return;
+
+        if (screenPoint is { } pointerScreenPoint && _draggedHostWindowPointerOffset is { } pointerOffset)
+        {
+            _draggedHostWindow.Position = new PixelPoint(
+                x: (int)Math.Round(pointerScreenPoint.X - pointerOffset.X),
+                y: (int)Math.Round(pointerScreenPoint.Y - pointerOffset.Y));
+
+            return;
+        }
+
+        // Fallback when screen coordinates are unavailable for the current pointer update.
+        _draggedHostWindow.DragWindow(dragVector.X, dragVector.Y);
+    }
+
+
+    private void ResetDetachedHostDragState()
+    {
+        _draggedHostWindow = null;
+        _draggedHostWindowPointerOffset = null;
     }
 
 
@@ -553,7 +612,7 @@ public class TabsControl : TabControl
         if (!EnableTabAttaching || e.ScreenPoint is null)
             return false;
 
-        if (!TryFindDropTarget(e.ScreenPoint.Value, out TabsControl? target) || target == this)
+        if (!TryFindDropTarget(e.ScreenPoint.Value, this, out TabsControl? target))
             return false;
 
         if (_draggedTabModel is null)
@@ -737,6 +796,8 @@ public class TabsControl : TabControl
             DataContext = DataContext
         };
 
+        detachedTabsControl._isDetachedHost = true;
+
         detachedTabsControl.LastTabClosedAction = LastTabClosedAction == _defaultLastTabClosedAction
             ? detachedTabsControl._defaultLastTabClosedAction
             : LastTabClosedAction;
@@ -801,12 +862,15 @@ public class TabsControl : TabControl
     }
 
 
-    private bool TryFindDropTarget(Point screenPoint, out TabsControl? target)
+    private bool TryFindDropTarget(Point screenPoint, TabsControl? excludedControl, out TabsControl? target)
     {
         target = null;
 
         foreach (TabsControl tabsControl in EnumerateRegisteredTabsControls())
         {
+            if (ReferenceEquals(tabsControl, excludedControl))
+                continue;
+
             if (!tabsControl.EnableTabAttaching)
                 continue;
 

--- a/Tabalonia/Controls/TabsControl.cs
+++ b/Tabalonia/Controls/TabsControl.cs
@@ -32,6 +32,7 @@ public class TabsControl : TabControl
     private DragTabItem? _draggedItem;
     private object? _draggedTabModel;
     private bool _dragging;
+    private bool _isDetachedHost;
     private bool _skipMoveTabModelsOnDragCompleted;
     private Point? _lastKnownDragScreenPoint;
     private TabsControl? _dragSessionSourceHost;
@@ -456,7 +457,7 @@ public class TabsControl : TabControl
         {
             _lastKnownDragScreenPoint = screenPoint;
 
-            if (ReferenceEquals(_dragSessionSourceHost, this))
+            if (ReferenceEquals(_dragSessionSourceHost, this) && !_isDetachedHost)
                 TryDetachDuringDrag(screenPoint);
 
             MoveDragSessionWindow(screenPoint);
@@ -496,7 +497,7 @@ public class TabsControl : TabControl
         bool sourceDetachedDuringDrag = !ReferenceEquals(sourceHost, this);
         bool transferredBetweenHosts = TryTransferToAnotherHost(releaseScreenPoint, sourceHost);
 
-        if (!transferredBetweenHosts && !sourceDetachedDuringDrag)
+        if (!transferredBetweenHosts && !sourceDetachedDuringDrag && !sourceHost._isDetachedHost)
             transferredBetweenHosts = TryDetachToNewWindow(releaseScreenPoint);
 
         if (!transferredBetweenHosts && sourceDetachedDuringDrag)
@@ -841,6 +842,8 @@ public class TabsControl : TabControl
             ItemsSource = new ObservableCollection<object?>(),
             DataContext = DataContext
         };
+
+        detachedTabsControl._isDetachedHost = true;
 
 
         detachedTabsControl.LastTabClosedAction = LastTabClosedAction == _defaultLastTabClosedAction

--- a/Tabalonia/Controls/TabsControl.cs
+++ b/Tabalonia/Controls/TabsControl.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Collections.ObjectModel;
 using System.Windows.Input;
 using Tabalonia.Events;
 using Tabalonia.Panels;
@@ -25,8 +26,16 @@ public class TabsControl : TabControl
 
     private readonly TabsPanel _tabsPanel;
 
+    private static readonly object RegistryLock = new();
+    private static readonly List<WeakReference<TabsControl>> RegisteredTabsControls = new();
+
     private DragTabItem? _draggedItem;
+    private object? _draggedTabModel;
     private bool _dragging;
+    private bool _skipMoveTabModelsOnDragCompleted;
+
+    private Control? _topPanel;
+    private readonly EventHandler<CloseLastTabEventArgs> _defaultLastTabClosedAction;
 
     private ICommand _addItemCommand;
     private ICommand _closeItemCommand;
@@ -105,6 +114,18 @@ public class TabsControl : TabControl
     
     public static readonly StyledProperty<object?> RightContentProperty =
         AvaloniaProperty.Register<TabsControl, object?>(nameof(RightContent));
+
+    public static readonly StyledProperty<bool> EnableTabDetachingProperty =
+        AvaloniaProperty.Register<TabsControl, bool>(nameof(EnableTabDetaching), defaultValue: true);
+
+    public static readonly StyledProperty<bool> EnableTabAttachingProperty =
+        AvaloniaProperty.Register<TabsControl, bool>(nameof(EnableTabAttaching), defaultValue: true);
+
+    public static readonly StyledProperty<double> DetachTriggerDistanceProperty =
+        AvaloniaProperty.Register<TabsControl, double>(nameof(DetachTriggerDistance), defaultValue: 32d);
+
+    public static readonly StyledProperty<Func<TabsControl, Window>?> DetachedWindowFactoryProperty =
+        AvaloniaProperty.Register<TabsControl, Func<TabsControl, Window>?>(nameof(DetachedWindowFactory));
     
     #endregion
 
@@ -127,7 +148,8 @@ public class TabsControl : TabControl
 
         ItemsPanel = new FuncTemplate<Panel>(() => _tabsPanel);
 
-        LastTabClosedAction = (_, _) => GetThisWindow()?.Close();
+        _defaultLastTabClosedAction = CreateDefaultLastTabClosedAction();
+        LastTabClosedAction = _defaultLastTabClosedAction;
 
         _addItemCommand = new SimpleActionCommand(AddItem);
         _closeItemCommand = new SimpleParamActionCommand(CloseItem);
@@ -249,6 +271,42 @@ public class TabsControl : TabControl
         get => GetValue(RightContentProperty);
         set => SetValue(RightContentProperty, value);
     }
+
+    /// <summary>
+    /// Enables creating a new host window when a tab drag ends outside of any registered tab strip.
+    /// </summary>
+    public bool EnableTabDetaching
+    {
+        get => GetValue(EnableTabDetachingProperty);
+        set => SetValue(EnableTabDetachingProperty, value);
+    }
+
+    /// <summary>
+    /// Enables dropping a dragged tab into another <see cref="TabsControl"/>.
+    /// </summary>
+    public bool EnableTabAttaching
+    {
+        get => GetValue(EnableTabAttachingProperty);
+        set => SetValue(EnableTabAttachingProperty, value);
+    }
+
+    /// <summary>
+    /// Screen-space tolerance around the tab strip where drag release is still treated as in-strip.
+    /// </summary>
+    public double DetachTriggerDistance
+    {
+        get => GetValue(DetachTriggerDistanceProperty);
+        set => SetValue(DetachTriggerDistanceProperty, value);
+    }
+
+    /// <summary>
+    /// Optional factory to create a host window for a detached tab.
+    /// </summary>
+    public Func<TabsControl, Window>? DetachedWindowFactory
+    {
+        get => GetValue(DetachedWindowFactoryProperty);
+        set => SetValue(DetachedWindowFactoryProperty, value);
+    }
     
     #endregion
 
@@ -258,6 +316,8 @@ public class TabsControl : TabControl
     protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
     {
         base.OnApplyTemplate(e);
+
+        _topPanel = e.NameScope.Get<Control>("PART_TopPanel");
 
         var leftDragWindowThumb = e.NameScope.Get<Thumb>("PART_LeftDragWindowThumb");
         leftDragWindowThumb.AddHandler(PointerPressedEvent, OnThumbBeginDrag, handledEventsToo: true);
@@ -272,6 +332,20 @@ public class TabsControl : TabControl
 
     protected override Control CreateContainerForItemOverride(object? item, int index, object? recycleKey) =>
         new DragTabItem();
+
+
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnAttachedToVisualTree(e);
+        RegisterTabsControl(this);
+    }
+
+
+    protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        UnregisterTabsControl(this);
+        base.OnDetachedFromVisualTree(e);
+    }
 
 
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
@@ -348,6 +422,8 @@ public class TabsControl : TabControl
     private void ItemDragStarted(object? sender, DragTabDragStartedEventArgs e)
     {
         _draggedItem = e.TabItem;
+        _draggedTabModel = ItemFromContainer(_draggedItem);
+        _skipMoveTabModelsOnDragCompleted = false;
 
         e.Handled = true;
 
@@ -393,6 +469,13 @@ public class TabsControl : TabControl
 
     private void ItemDragCompleted(object? sender, DragTabDragCompletedEventArgs e)
     {
+        bool transferredBetweenHosts = TryTransferToAnotherHost(e);
+
+        if (!transferredBetweenHosts)
+            transferredBetweenHosts = TryDetachToNewWindow(e);
+
+        _skipMoveTabModelsOnDragCompleted = transferredBetweenHosts;
+
         foreach (var item in DragTabItems())
         {
             item.IsDragging = false;
@@ -420,14 +503,26 @@ public class TabsControl : TabControl
 
     private void TabsPanelOnDragCompleted()
     {
+        if (_skipMoveTabModelsOnDragCompleted)
+        {
+            _skipMoveTabModelsOnDragCompleted = false;
+            _draggedItem = null;
+            _draggedTabModel = null;
+            return;
+        }
+
         MoveTabModelsIfNeeded();
 
         _draggedItem = null;
+        _draggedTabModel = null;
     }
 
 
     private void MoveTabModelsIfNeeded()
     {
+        if (_draggedItem is null)
+            return;
+
         object? item = ItemFromContainer(_draggedItem);
 
         if (item != null)
@@ -448,6 +543,290 @@ public class TabsControl : TabControl
                     foreach (var dragTabItem in DragTabItems())
                         dragTabItem.LogicalIndex = i++;
                 }
+            }
+        }
+    }
+
+
+    private bool TryTransferToAnotherHost(DragTabDragCompletedEventArgs e)
+    {
+        if (!EnableTabAttaching || e.ScreenPoint is null)
+            return false;
+
+        if (!TryFindDropTarget(e.ScreenPoint.Value, out TabsControl? target) || target == this)
+            return false;
+
+        if (_draggedTabModel is null)
+            return false;
+
+        return MoveItemToAnotherTabsControl(_draggedTabModel, target);
+    }
+
+
+    private bool TryDetachToNewWindow(DragTabDragCompletedEventArgs e)
+    {
+        if (!EnableTabDetaching || e.ScreenPoint is null)
+            return false;
+
+        if (!ShouldDetachForScreenPoint(e.ScreenPoint.Value))
+            return false;
+
+        if (_draggedTabModel is null)
+            return false;
+
+        return DetachItemToNewWindow(_draggedTabModel, e.ScreenPoint.Value);
+    }
+
+
+    private bool MoveItemToAnotherTabsControl(object item, TabsControl target)
+    {
+        if (ReferenceEquals(target, this))
+            return false;
+
+        if (ItemsSource is not IList sourceItems || target.ItemsSource is not IList targetItems)
+            return false;
+
+        int sourceIndex = sourceItems.IndexOf(item);
+
+        if (sourceIndex < 0)
+            return false;
+
+        bool removedItemWasSelected = Equals(SelectedItem, item);
+
+        sourceItems.RemoveAt(sourceIndex);
+
+        targetItems.Add(item);
+        target.SelectedItem = item;
+
+        HandleSourceItemsChangedAfterTransfer(sourceItems, sourceIndex, removedItemWasSelected);
+
+        return true;
+    }
+
+
+    private bool DetachItemToNewWindow(object item, Point releaseScreenPoint)
+    {
+        if (ItemsSource is not IList sourceItems)
+            return false;
+
+        int sourceIndex = sourceItems.IndexOf(item);
+
+        if (sourceIndex < 0)
+            return false;
+
+        TabsControl detachedTabsControl = CreateDetachedTabsControl();
+
+        if (detachedTabsControl.ItemsSource is not IList detachedItems)
+            return false;
+
+        bool removedItemWasSelected = Equals(SelectedItem, item);
+
+        sourceItems.RemoveAt(sourceIndex);
+
+        detachedItems.Add(item);
+        detachedTabsControl.SelectedItem = item;
+
+        Window detachedWindow = DetachedWindowFactory?.Invoke(detachedTabsControl)
+                                ?? CreateDefaultDetachedWindow(detachedTabsControl);
+
+        detachedWindow.Position = new PixelPoint(
+            x: (int)releaseScreenPoint.X - 120,
+            y: (int)releaseScreenPoint.Y - 20);
+
+        detachedWindow.Show();
+
+        HandleSourceItemsChangedAfterTransfer(sourceItems, sourceIndex, removedItemWasSelected);
+
+        return true;
+    }
+
+
+    private TabsControl CreateDetachedTabsControl()
+    {
+        var detachedTabsControl = new TabsControl
+        {
+            AdjacentHeaderItemOffset = AdjacentHeaderItemOffset,
+            TabItemWidth = TabItemWidth,
+            ShowDefaultCloseButton = ShowDefaultCloseButton,
+            ShowDefaultAddButton = ShowDefaultAddButton,
+            FixedHeaderCount = FixedHeaderCount,
+            NewItemAsyncFactory = NewItemAsyncFactory,
+            NewItemFactory = NewItemFactory,
+            TabClosed = TabClosed,
+            TabClosing = TabClosing,
+            LeftThumbWidth = LeftThumbWidth,
+            RightThumbWidth = RightThumbWidth,
+            EnableTabDetaching = EnableTabDetaching,
+            EnableTabAttaching = EnableTabAttaching,
+            DetachTriggerDistance = DetachTriggerDistance,
+            DetachedWindowFactory = DetachedWindowFactory,
+            ItemTemplate = ItemTemplate,
+            ContentTemplate = ContentTemplate,
+            ItemsSource = new ObservableCollection<object?>(),
+            DataContext = DataContext
+        };
+
+        detachedTabsControl.LastTabClosedAction = LastTabClosedAction == _defaultLastTabClosedAction
+            ? detachedTabsControl._defaultLastTabClosedAction
+            : LastTabClosedAction;
+
+        return detachedTabsControl;
+    }
+
+
+    private void HandleSourceItemsChangedAfterTransfer(IList sourceItems, int removedItemIndex, bool removedItemWasSelected)
+    {
+        if (sourceItems.Count == 0)
+        {
+            Dispatcher.UIThread.Post(
+                () => LastTabClosedAction?.Invoke(this, new CloseLastTabEventArgs(GetThisWindow())),
+                DispatcherPriority.Background);
+
+            return;
+        }
+
+        if (removedItemWasSelected)
+            SetSelectedNewTab(sourceItems, removedItemIndex);
+    }
+
+
+    private static EventHandler<CloseLastTabEventArgs> CreateDefaultLastTabClosedAction() =>
+        (_, args) => args.Window?.Close();
+
+
+    private Window CreateDefaultDetachedWindow(TabsControl detachedTabsControl)
+    {
+        Window? sourceWindow = GetThisWindow();
+
+        var detachedWindow = new Window
+        {
+            Width = sourceWindow?.Bounds.Width is > 0 ? sourceWindow.Bounds.Width : 900,
+            Height = sourceWindow?.Bounds.Height is > 0 ? sourceWindow.Bounds.Height : 600,
+            MinWidth = sourceWindow?.MinWidth ?? 320,
+            MinHeight = sourceWindow?.MinHeight ?? 240,
+            Background = sourceWindow?.Background,
+            SystemDecorations = sourceWindow?.SystemDecorations ?? SystemDecorations.Full,
+            ExtendClientAreaToDecorationsHint = sourceWindow?.ExtendClientAreaToDecorationsHint ?? false,
+            Content = detachedTabsControl,
+            DataContext = detachedTabsControl.DataContext,
+            Title = sourceWindow?.Title ?? "Detached Tab"
+        };
+
+        if (sourceWindow?.Icon is { } sourceIcon)
+            detachedWindow.Icon = sourceIcon;
+
+        return detachedWindow;
+    }
+
+
+    private bool ShouldDetachForScreenPoint(Point screenPoint)
+    {
+        if (!TryGetDropBoundsInScreen(out Rect bounds))
+            return false;
+
+        var expandedBounds = bounds.Inflate(DetachTriggerDistance);
+
+        return !expandedBounds.Contains(screenPoint);
+    }
+
+
+    private bool TryFindDropTarget(Point screenPoint, out TabsControl? target)
+    {
+        target = null;
+
+        foreach (TabsControl tabsControl in EnumerateRegisteredTabsControls())
+        {
+            if (!tabsControl.EnableTabAttaching)
+                continue;
+
+            if (!tabsControl.TryGetDropBoundsInScreen(out Rect bounds))
+                continue;
+
+            if (bounds.Contains(screenPoint))
+            {
+                target = tabsControl;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+
+    private bool TryGetDropBoundsInScreen(out Rect bounds)
+    {
+        bounds = default;
+
+        if (_topPanel is null)
+            return false;
+
+        TopLevel? topLevel = TopLevel.GetTopLevel(_topPanel);
+
+        if (topLevel is null)
+            return false;
+
+        Point? topLeftInTopLevel = _topPanel.TranslatePoint(new Point(0, 0), topLevel);
+
+        if (topLeftInTopLevel is null)
+            return false;
+
+        PixelPoint topLeftScreen = topLevel.PointToScreen(topLeftInTopLevel.Value);
+        PixelPoint bottomRightScreen = topLevel.PointToScreen(topLeftInTopLevel.Value + new Vector(_topPanel.Bounds.Width, _topPanel.Bounds.Height));
+
+        bounds = new Rect(
+            x: topLeftScreen.X,
+            y: topLeftScreen.Y,
+            width: Math.Max(1, bottomRightScreen.X - topLeftScreen.X),
+            height: Math.Max(1, bottomRightScreen.Y - topLeftScreen.Y));
+
+        return true;
+    }
+
+
+    private static IEnumerable<TabsControl> EnumerateRegisteredTabsControls()
+    {
+        List<TabsControl> aliveControls = new();
+
+        lock (RegistryLock)
+        {
+            for (int i = RegisteredTabsControls.Count - 1; i >= 0; i--)
+            {
+                if (RegisteredTabsControls[i].TryGetTarget(out TabsControl? tabsControl))
+                {
+                    aliveControls.Add(tabsControl);
+                }
+                else
+                {
+                    RegisteredTabsControls.RemoveAt(i);
+                }
+            }
+        }
+
+        return aliveControls;
+    }
+
+
+    private static void RegisterTabsControl(TabsControl tabsControl)
+    {
+        lock (RegistryLock)
+        {
+            bool alreadyRegistered = RegisteredTabsControls.Any(reference =>
+                reference.TryGetTarget(out TabsControl? existing) && ReferenceEquals(existing, tabsControl));
+
+            if (!alreadyRegistered)
+                RegisteredTabsControls.Add(new WeakReference<TabsControl>(tabsControl));
+        }
+    }
+
+
+    private static void UnregisterTabsControl(TabsControl tabsControl)
+    {
+        lock (RegistryLock)
+        {
+            for (int i = RegisteredTabsControls.Count - 1; i >= 0; i--)
+            {
+                if (!RegisteredTabsControls[i].TryGetTarget(out TabsControl? existing) || ReferenceEquals(existing, tabsControl))
+                    RegisteredTabsControls.RemoveAt(i);
             }
         }
     }

--- a/Tabalonia/Controls/TabsControl.cs
+++ b/Tabalonia/Controls/TabsControl.cs
@@ -949,7 +949,7 @@ public class TabsControl : TabControl
             MinWidth = sourceWindow?.MinWidth ?? 320,
             MinHeight = sourceWindow?.MinHeight ?? 240,
             Background = sourceWindow?.Background,
-            SystemDecorations = sourceWindow?.SystemDecorations ?? SystemDecorations.Full,
+            WindowDecorations = sourceWindow?.WindowDecorations ?? WindowDecorations.Full,
             ExtendClientAreaToDecorationsHint = sourceWindow?.ExtendClientAreaToDecorationsHint ?? false,
             Content = detachedTabsControl,
             DataContext = detachedTabsControl.DataContext,

--- a/Tabalonia/Events/DragTabDragCompletedEventArgs.cs
+++ b/Tabalonia/Events/DragTabDragCompletedEventArgs.cs
@@ -11,10 +11,22 @@ public class DragTabDragCompletedEventArgs : DragTabItemEventArgs
         //DragCompletedEventArgs = dragCompletedEventArgs ?? throw new ArgumentNullException(nameof(dragCompletedEventArgs));
     }
 
+    public DragTabDragCompletedEventArgs(DragTabItem dragItem, VectorEventArgs dragCompletedEventArgs, Point? screenPoint)
+        : this(dragItem, dragCompletedEventArgs)
+    {
+        ScreenPoint = screenPoint;
+    }
+
     public DragTabDragCompletedEventArgs(RoutedEvent routedEvent, DragTabItem dragItem, VectorEventArgs dragCompletedEventArgs)
         : base(routedEvent, dragItem)
     {
         //DragCompletedEventArgs = dragCompletedEventArgs ?? throw new ArgumentNullException(nameof(dragCompletedEventArgs));
+    }
+
+    public DragTabDragCompletedEventArgs(RoutedEvent routedEvent, DragTabItem dragItem, VectorEventArgs dragCompletedEventArgs, Point? screenPoint)
+        : this(routedEvent, dragItem, dragCompletedEventArgs)
+    {
+        ScreenPoint = screenPoint;
     }
 
     public DragTabDragCompletedEventArgs(RoutedEvent routedEvent, Interactive source, DragTabItem dragItem, VectorEventArgs dragCompletedEventArgs)
@@ -24,6 +36,19 @@ public class DragTabDragCompletedEventArgs : DragTabItemEventArgs
         //DragCompletedEventArgs = dragCompletedEventArgs ?? throw new ArgumentNullException(nameof(dragCompletedEventArgs));
     }
 
+    public DragTabDragCompletedEventArgs(
+        RoutedEvent routedEvent,
+        Interactive source,
+        DragTabItem dragItem,
+        VectorEventArgs dragCompletedEventArgs,
+        Point? screenPoint)
+        : this(routedEvent, source, dragItem, dragCompletedEventArgs)
+    {
+        ScreenPoint = screenPoint;
+    }
+
 
     //public VectorEventArgs DragCompletedEventArgs { get; }
+
+    public Point? ScreenPoint { get; }
 }

--- a/Tabalonia/Events/DragTabDragDeltaEventArgs.cs
+++ b/Tabalonia/Events/DragTabDragDeltaEventArgs.cs
@@ -11,10 +11,22 @@ public class DragTabDragDeltaEventArgs : DragTabItemEventArgs
         DragDeltaEventArgs = dragDeltaEventArgs ?? throw new ArgumentNullException(nameof(dragDeltaEventArgs));
     }
 
+    public DragTabDragDeltaEventArgs(DragTabItem dragTabItem, VectorEventArgs dragDeltaEventArgs, Point? screenPoint)
+        : this(dragTabItem, dragDeltaEventArgs)
+    {
+        ScreenPoint = screenPoint;
+    }
+
     public DragTabDragDeltaEventArgs(RoutedEvent routedEvent, DragTabItem tabItem, VectorEventArgs dragDeltaEventArgs) 
         : base(routedEvent, tabItem)
     {
         DragDeltaEventArgs = dragDeltaEventArgs ?? throw new ArgumentNullException(nameof(dragDeltaEventArgs));
+    }
+
+    public DragTabDragDeltaEventArgs(RoutedEvent routedEvent, DragTabItem tabItem, VectorEventArgs dragDeltaEventArgs, Point? screenPoint)
+        : this(routedEvent, tabItem, dragDeltaEventArgs)
+    {
+        ScreenPoint = screenPoint;
     }
 
     public DragTabDragDeltaEventArgs(RoutedEvent routedEvent, Interactive source, DragTabItem tabItem, VectorEventArgs dragDeltaEventArgs) 
@@ -23,7 +35,20 @@ public class DragTabDragDeltaEventArgs : DragTabItemEventArgs
         DragDeltaEventArgs = dragDeltaEventArgs ?? throw new ArgumentNullException(nameof(dragDeltaEventArgs));
     }
 
+    public DragTabDragDeltaEventArgs(
+        RoutedEvent routedEvent,
+        Interactive source,
+        DragTabItem tabItem,
+        VectorEventArgs dragDeltaEventArgs,
+        Point? screenPoint)
+        : this(routedEvent, source, tabItem, dragDeltaEventArgs)
+    {
+        ScreenPoint = screenPoint;
+    }
+
     public VectorEventArgs DragDeltaEventArgs { get; }
+
+    public Point? ScreenPoint { get; }
 
     public bool Cancel { get; set; }        
 }

--- a/Tabalonia/Events/DragTabDragStartedEventArgs.cs
+++ b/Tabalonia/Events/DragTabDragStartedEventArgs.cs
@@ -11,10 +11,22 @@ public class DragTabDragStartedEventArgs : DragTabItemEventArgs
         //DragStartedEventArgs = dragStartedEventArgs ?? throw new ArgumentNullException(nameof(dragStartedEventArgs));
     }
 
+    public DragTabDragStartedEventArgs(DragTabItem dragTabItem, VectorEventArgs dragStartedEventArgs, Point? screenPoint)
+        : this(dragTabItem, dragStartedEventArgs)
+    {
+        ScreenPoint = screenPoint;
+    }
+
     public DragTabDragStartedEventArgs(RoutedEvent routedEvent, DragTabItem tabItem, VectorEventArgs dragStartedEventArgs)
         : base(routedEvent, tabItem)
     {
         //DragStartedEventArgs = dragStartedEventArgs;
+    }
+
+    public DragTabDragStartedEventArgs(RoutedEvent routedEvent, DragTabItem tabItem, VectorEventArgs dragStartedEventArgs, Point? screenPoint)
+        : this(routedEvent, tabItem, dragStartedEventArgs)
+    {
+        ScreenPoint = screenPoint;
     }
 
     public DragTabDragStartedEventArgs(RoutedEvent routedEvent, Interactive source, DragTabItem tabItem, VectorEventArgs dragStartedEventArgs)
@@ -23,5 +35,18 @@ public class DragTabDragStartedEventArgs : DragTabItemEventArgs
         //DragStartedEventArgs = dragStartedEventArgs;
     }
 
+    public DragTabDragStartedEventArgs(
+        RoutedEvent routedEvent,
+        Interactive source,
+        DragTabItem tabItem,
+        VectorEventArgs dragStartedEventArgs,
+        Point? screenPoint)
+        : this(routedEvent, source, tabItem, dragStartedEventArgs)
+    {
+        ScreenPoint = screenPoint;
+    }
+
     //public VectorEventArgs DragStartedEventArgs { get; }
+
+    public Point? ScreenPoint { get; }
 }


### PR DESCRIPTION
I'm working on a project where Tabalonia is well-suited, other than a few missing features.

I am not well-versed in Avalonia and have relied heavily on copilot to add the drag-and-drop detach/reattach support.

In light manual testing, it appears to work, but it is not as smooth as I want it to be.   I'm looking for feedback on how to progress this work and improve it.  

It is functional in both the demo app and a private app I am working on.

demo video


https://github.com/user-attachments/assets/1e409b6e-1ff0-45b5-89bc-a872654cfee4



### copilot summary
This pull request enhances the drag-and-drop functionality in the tab controls by adding support for tracking the screen coordinates of drag events. The changes introduce a new `ScreenPoint` property to the drag event argument classes and ensure that this property is set and propagated throughout the drag lifecycle. This will allow consumers of these events to know the precise screen location where drag actions occur, which is useful for advanced UI behaviors such as drag previews or docking.

Key changes include:

**Event Argument Enhancements:**

* Added a nullable `ScreenPoint` property to `DragTabDragStartedEventArgs`, `DragTabDragDeltaEventArgs`, and `DragTabDragCompletedEventArgs`, along with corresponding constructors to initialize this property. [[1]](diffhunk://#diff-0bc0e6d2c0fb89fe031fec0a4c80c9a9fb1cef0f888afd565c25c9c57d57a028R14-R51) [[2]](diffhunk://#diff-c001005bd13ab6059bf89d9a3a2e41d4c7d40bc63dd70cf49d1d70d409717a45R14-R52) [[3]](diffhunk://#diff-436e2e14b0c08c8215a271263a82bca795587c53617d7a851889cd9b94a4e99bR14-R53)

**Thumb Control Updates:**

* Introduced the `LastScreenPoint` property in `LeftPressedThumb` to track the most recent screen coordinates during pointer events.
* Implemented the `GetScreenPoint` helper method in `LeftPressedThumb` to convert pointer positions to screen coordinates.

**Event Propagation and Lifecycle:**

* Updated drag event handling in `DragTabItem` to pass the `LastScreenPoint` from the thumb control into the drag event argument constructors, ensuring screen position is available during drag start, delta, and completion events. [[1]](diffhunk://#diff-0ba6b264660a3f82d6d9d7f8dc79e9f0beae06bf6c230fcf6b230215d005d159L151-R163) [[2]](diffhunk://#diff-0ba6b264660a3f82d6d9d7f8dc79e9f0beae06bf6c230fcf6b230215d005d159L173-R173)
* Ensured `LastScreenPoint` is correctly set and cleared at appropriate points in the pointer event lifecycle within `LeftPressedThumb`, including pointer pressed, moved, released, and capture lost events. [[1]](diffhunk://#diff-3d27dce56a304d90b733bca36a2289bfd11214cc3bbe60de4820d32bfbe3487aR70-R71) [[2]](diffhunk://#diff-3d27dce56a304d90b733bca36a2289bfd11214cc3bbe60de4820d32bfbe3487aR90-R92) [[3]](diffhunk://#diff-3d27dce56a304d90b733bca36a2289bfd11214cc3bbe60de4820d32bfbe3487aL101-R113) [[4]](diffhunk://#diff-3d27dce56a304d90b733bca36a2289bfd11214cc3bbe60de4820d32bfbe3487aR57) [[5]](diffhunk://#diff-3d27dce56a304d90b733bca36a2289bfd11214cc3bbe60de4820d32bfbe3487aR122-R123)

These updates provide more granular information about drag operations, enabling richer user interaction scenarios.